### PR TITLE
Add environment_probs.yml conda environment

### DIFF
--- a/environment_probs.yml
+++ b/environment_probs.yml
@@ -1,0 +1,18 @@
+name: un-og-training-probs
+channels:
+- conda-forge
+dependencies:
+- python>=3.10, <3.13
+- numpy
+- scipy
+- pandas
+- ipython
+- matplotlib
+- bokeh
+- jupyter
+- pip
+- pip:
+  - ogcore
+  - ogusa
+  - linecheck
+  - git+https://github.com/EAPD-DRB/OG-ZAF.git

--- a/environment_probs.yml
+++ b/environment_probs.yml
@@ -2,7 +2,7 @@ name: un-og-training-probs
 channels:
 - conda-forge
 dependencies:
-- python>=3.10, <3.13
+- python>=3.10, <3.12
 - numpy
 - scipy
 - pandas


### PR DESCRIPTION
This PR adds the `environment_probs.yml` conda environment specification file to the repository, which can be used by users working through the exercises. This file can be used to create the `un-og-training-probs` conda environment, which does not have all the Jupyter Book and Sphinx packages that are in this repo's main `enviroment.yml` file.