### PR TITLE
Updated miniconda version in GH Actions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Miniconda using Python ${{ matrix.python-version }}
         uses: conda-incubator/setup-miniconda@v3
         with:
-          miniforge-variant: Mambaforge
+          miniconda-version: "latest"
           auto-update-conda: true
           activate-environment: un-og-training-dev
           environment-file: environment.yml

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@v3
         with:
-          miniforge-variant: Mambaforge
+          miniconda-version: "latest"
           activate-environment: un-og-training-dev
           environment-file: environment.yml
           python-version: "3.11"

--- a/.github/workflows/docs_check.yml
+++ b/.github/workflows/docs_check.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@v3
         with:
-          miniforge-variant: Mambaforge
+          miniconda-version: "latest"
           activate-environment: un-og-training-dev
           environment-file: environment.yml
           python-version: "3.11"


### PR DESCRIPTION
This PR updates the miniconda Python installer in our GitHub Actions to Miniconda instead of the now deprecated Mambaforge. All our actions currently use Mambaforge (see Issue #3 and this blog post "[Sunsetting Mambaforge](https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/)").

cc: @jdebacker @SeaCelo 